### PR TITLE
T4 dma low - Issues of trying to do DMA on T4 if object created in heap

### DIFF
--- a/ST7735_t3.cpp
+++ b/ST7735_t3.cpp
@@ -46,15 +46,9 @@ ST7735DMA_Data ST7735_t3::_dma_data[3];   // one structure for each SPI buss...
 
 // Constructor when using software SPI.  All output pins are configurable.
 ST7735_t3::ST7735_t3(uint8_t cs, uint8_t rs, uint8_t sid, uint8_t sclk, uint8_t rst) :
- Adafruit_GFX(ST7735_TFTWIDTH, ST7735_TFTHEIGHT_160)
+ 	Adafruit_GFX(ST7735_TFTWIDTH, ST7735_TFTHEIGHT_160), hwSPI(false),
+	_cs(cs), _rs(rs),  _rst(rst), _sid(sid), _sclk(sclk)
 {
-	_cs   = cs;
-	_rs   = rs;
-	_sid  = sid;
-	_sclk = sclk;
-	_rst  = rst;
-	_rot = 0xff;
-	hwSPI = false;
 	#ifdef ENABLE_ST77XX_FRAMEBUFFER
     _pfbtft = NULL;	
     _use_fbtft = 0;						// Are we in frame buffer mode?
@@ -69,13 +63,9 @@ ST7735_t3::ST7735_t3(uint8_t cs, uint8_t rs, uint8_t sid, uint8_t sclk, uint8_t 
 // Constructor when using hardware SPI.  Faster, but must use SPI pins
 // specific to each board type (e.g. 11,13 for Uno, 51,52 for Mega, etc.)
 ST7735_t3::ST7735_t3(uint8_t cs, uint8_t rs, uint8_t rst) :
-  Adafruit_GFX(ST7735_TFTWIDTH, ST7735_TFTHEIGHT_160) {
-	_cs   = cs;
-	_rs   = rs;
-	_rst  = rst;
-	_rot = 0xff;
-	hwSPI = true;
-	_sid  = _sclk = (uint8_t)-1;
+	Adafruit_GFX(ST7735_TFTWIDTH, ST7735_TFTHEIGHT_160), hwSPI(true),
+	_cs(cs), _rs(rs),  _rst(rst), _sid((uint8_t)-1), _sclk((uint8_t)-1)
+{
 	#ifdef ENABLE_ST77XX_FRAMEBUFFER
     _pfbtft = NULL;	
     _use_fbtft = 0;						// Are we in frame buffer mode?

--- a/ST7735_t3.cpp
+++ b/ST7735_t3.cpp
@@ -126,9 +126,16 @@ void ST7735_t3::writecommand(uint8_t c)
 }
 
 void ST7735_t3::writecommand_last(uint8_t c) {
-	uint32_t mcr = _pkinetisk_spi->MCR;
-	_pkinetisk_spi->PUSHR = c | (pcs_command << 16) | SPI_PUSHR_CTAS(0) | SPI_PUSHR_EOQ;
-	waitTransmitComplete(mcr);
+	if (hwSPI) {
+		uint32_t mcr = _pkinetisk_spi->MCR;
+		_pkinetisk_spi->PUSHR = c | (pcs_command << 16) | SPI_PUSHR_CTAS(0) | SPI_PUSHR_EOQ;
+		waitTransmitComplete(mcr);
+	} else {
+		*rspin = 0;
+		*cspin = 0;
+		spiwrite(c);
+		*cspin = 1;
+	}
 }
 
 void ST7735_t3::writedata(uint8_t c)

--- a/ST7735_t3.cpp
+++ b/ST7735_t3.cpp
@@ -105,11 +105,28 @@ inline void ST7735_t3::waitTransmitComplete(uint32_t mcr) {
 
 inline void ST7735_t3::spiwrite(uint8_t c)
 {
+	// pass 1 if we actually are setup to with MOSI and SCLK on hardware SPI use it...
+	if (_pspi) {
+		_pspi->transfer(c);
+		return;
+	}
+
 	for (uint8_t bit = 0x80; bit; bit >>= 1) {
 		*datapin = ((c & bit) ? 1 : 0);
 		*clkpin = 1;
 		*clkpin = 0;
 	}
+}
+
+inline void ST7735_t3::spiwrite16(uint16_t d)
+{
+	// pass 1 if we actually are setup to with MOSI and SCLK on hardware SPI use it...
+	if (_pspi) {
+		_pspi->transfer16(d);
+		return;
+	}
+	spiwrite(d >> 8);
+	spiwrite(d);
 }
 
 void ST7735_t3::writecommand(uint8_t c)
@@ -119,9 +136,7 @@ void ST7735_t3::writecommand(uint8_t c)
 		while (((_pkinetisk_spi->SR) & (15 << 12)) > _fifo_full_test) ; // wait if FIFO full
 	} else {
 		*rspin = 0;
-		*cspin = 0;
 		spiwrite(c);
-		*cspin = 1;
 	}
 }
 
@@ -132,9 +147,7 @@ void ST7735_t3::writecommand_last(uint8_t c) {
 		waitTransmitComplete(mcr);
 	} else {
 		*rspin = 0;
-		*cspin = 0;
 		spiwrite(c);
-		*cspin = 1;
 	}
 }
 
@@ -145,9 +158,7 @@ void ST7735_t3::writedata(uint8_t c)
 		while (((_pkinetisk_spi->SR) & (15 << 12)) > _fifo_full_test) ; // wait if FIFO full
 	} else {
 		*rspin = 1;
-		*cspin = 0;
 		spiwrite(c);
-		*cspin = 1;
 	}
 }
 
@@ -159,9 +170,7 @@ void ST7735_t3::writedata_last(uint8_t c)
 		waitTransmitComplete(mcr);
 	} else {
 		*rspin = 1;
-		*cspin = 0;
 		spiwrite(c);
-		*cspin = 1;
 	}
 }
 
@@ -172,13 +181,9 @@ void ST7735_t3::writedata16(uint16_t d)
 		while (((_pkinetisk_spi->SR) & (15 << 12)) > _fifo_full_test) ; // wait if FIFO full
 	} else {
 		*rspin = 1;
-		*cspin = 0;
-		spiwrite(d >> 8);
-		spiwrite(d);
-		*cspin = 1;
+		spiwrite16(d);
 	}
 }
-
 
 
 void ST7735_t3::writedata16_last(uint16_t d)
@@ -189,8 +194,7 @@ void ST7735_t3::writedata16_last(uint16_t d)
 		waitTransmitComplete(mcr);
 	} else {
 		*rspin = 1;
-		spiwrite(d >> 8);
-		spiwrite(d);
+		spiwrite16(d);
 	}
 }
 
@@ -619,7 +623,9 @@ void ST7735_t3::commonInit(const uint8_t *cmdList, uint8_t mode)
 	if (_sid == (uint8_t)-1) _sid = 11;
 	if (_sclk == (uint8_t)-1) _sclk = 13;
 
-	if (SPI.pinIsMOSI(_sid) && SPI.pinIsSCK(_sclk) && SPI.pinIsChipSelect(_rs)) {
+	// Lets try to handle cases where DC is not hardware, without going all the way down to bit bang!
+	//if (SPI.pinIsMOSI(_sid) && SPI.pinIsSCK(_sclk) && SPI.pinIsChipSelect(_rs)) {
+	if (SPI.pinIsMOSI(_sid) && SPI.pinIsSCK(_sclk)) {
 		_pspi = &SPI;
 		_spi_num = 0;          // Which buss is this spi on? 
 		_pkinetisk_spi = &KINETISK_SPI0;  // Could hack our way to grab this from SPI object, but...
@@ -627,14 +633,14 @@ void ST7735_t3::commonInit(const uint8_t *cmdList, uint8_t mode)
 		//Serial.println("ST7735_t3::commonInit SPI");
 
     #if  defined(__MK64FX512__) || defined(__MK66FX1M0__)
-	} else if (SPI1.pinIsMOSI(_sid) && SPI1.pinIsSCK(_sclk) && SPI1.pinIsChipSelect(_rs)) {
+	} else if (SPI1.pinIsMOSI(_sid) && SPI1.pinIsSCK(_sclk)) {
 		_pspi = &SPI1;
 		_spi_num = 1;          // Which buss is this spi on? 
 
 		_pkinetisk_spi = &KINETISK_SPI1;
 		_fifo_full_test = (0 << 12);
 		//Serial.println("ST7735_t3::commonInit SPI1");
-	} else if (SPI2.pinIsMOSI(_sid) && SPI2.pinIsSCK(_sclk) && SPI2.pinIsChipSelect(_rs)) {
+	} else if (SPI2.pinIsMOSI(_sid) && SPI2.pinIsSCK(_sclk)) {
 		_pspi = &SPI2;
 		_spi_num = 2;          // Which buss is this spi on? 
 		_pkinetisk_spi = &KINETISK_SPI2;
@@ -656,7 +662,8 @@ void ST7735_t3::commonInit(const uint8_t *cmdList, uint8_t mode)
 			pcs_command = pcs_data | _pspi->setCS(_rs);
 			cspin = 0; // Let know that we are not setting manual
 			//Serial.println("Both CS and DC are SPI pins");
-		} else {
+		// See if at least DC is hardware CS... 	
+		} else if (_pspi->pinIsChipSelect(_rs)) {
 			// We already verified that _rs was valid CS pin above.
 			pcs_data = 0;
 			pcs_command = pcs_data | _pspi->setCS(_rs);
@@ -665,12 +672,28 @@ void ST7735_t3::commonInit(const uint8_t *cmdList, uint8_t mode)
 				cspin = portOutputRegister(digitalPinToPort(_cs));
 				*cspin = 1;
 			}
+		} else {
+			// DC is not, and won't bother to check CS... 
+			pcs_data = 0;
+			pcs_command = 0;
+			if (_cs != 0xff) {
+				pinMode(_cs, OUTPUT);
+				cspin = portOutputRegister(digitalPinToPort(_cs));
+				*cspin = 1;
+			}
+			pinMode(_rs, OUTPUT);
+			rspin = portOutputRegister(digitalPinToPort(_rs));
+			*rspin = 0;
+			// Pass 1, now lets set hwSPI false
+			hwSPI = false;
 		}
 		// Hack to get hold of the SPI Hardware information... 
 	 	uint32_t *pa = (uint32_t*)((void*)_pspi);
 		_spi_hardware = (SPIClass::SPI_Hardware_t*)(void*)pa[1];
 	} else {
+		//Serial.println("ST7735_t3::commonInit Software SPI :(");
 		hwSPI = false;
+		_pspi = nullptr;
 		cspin = (_cs != 0xff)? portOutputRegister(digitalPinToPort(_cs)) : 0;
 		rspin = portOutputRegister(digitalPinToPort(_rs));
 		clkpin = portOutputRegister(digitalPinToPort(_sclk));

--- a/ST7735_t3.h
+++ b/ST7735_t3.h
@@ -234,6 +234,7 @@ class ST7735_t3 : public Adafruit_GFX {
   uint8_t  tabcolor;
 
   void     spiwrite(uint8_t),
+           spiwrite16(uint16_t d),
            writecommand(uint8_t c),
            writecommand_last(uint8_t c),
            writedata(uint8_t d),

--- a/ST7735_t3.h
+++ b/ST7735_t3.h
@@ -244,7 +244,7 @@ class ST7735_t3 : public Adafruit_GFX {
            commonInit(const uint8_t *cmdList, uint8_t mode=SPI_MODE0);
 //uint8_t  spiread(void);
 
-  boolean  hwSPI;
+  boolean  hwSPI=true;
 
 
   uint16_t _colstart, _rowstart, _xstart, _ystart, _rot, _screenHeight, _screenWidth;
@@ -256,12 +256,12 @@ class ST7735_t3 : public Adafruit_GFX {
   volatile uint8_t *datapin, *clkpin, *cspin, *rspin;
 
   SPIClass *_pspi = nullptr;
-  uint8_t   _spi_num;          // Which buss is this spi on? 
-  KINETISK_SPI_t *_pkinetisk_spi;
-  SPIClass::SPI_Hardware_t *_spi_hardware;
+  uint8_t   _spi_num = 0;          // Which buss is this spi on? 
+  KINETISK_SPI_t *_pkinetisk_spi = nullptr;
+  SPIClass::SPI_Hardware_t *_spi_hardware = nullptr;
   void waitTransmitComplete(void);
   void waitTransmitComplete(uint32_t mcr);
-  uint32_t _fifo_full_test;
+  uint32_t _fifo_full_test = 0;
 
   inline void beginSPITransaction() {
     if (_pspi) _pspi->beginTransaction(_spiSettings);
@@ -278,11 +278,11 @@ class ST7735_t3 : public Adafruit_GFX {
 #endif
 #if defined(__IMXRT1062__)  // Teensy 4.x
   SPIClass *_pspi = nullptr;
-  uint8_t   _spi_num;          // Which buss is this spi on? 
+  uint8_t   _spi_num = 0;          // Which buss is this spi on? 
   IMXRT_LPSPI_t *_pimxrt_spi = nullptr;
   SPIClass::SPI_Hardware_t *_spi_hardware;
   uint8_t _pending_rx_count = 0;
-  uint32_t _spi_tcr_current;
+  uint32_t _spi_tcr_current = 0; 
 
 
   void DIRECT_WRITE_LOW(volatile uint32_t * base, uint32_t mask)  __attribute__((always_inline)) {

--- a/ST7735_t3.h
+++ b/ST7735_t3.h
@@ -396,7 +396,7 @@ volatile uint8_t *dataport, *clkport, *csport, *rsport;
 
   #if defined(__MK66FX1M0__) 
   // T3.6 use Scatter/gather with chain to do transfer
-  DMASetting   _dmasettings[4];
+  static DMASetting   _dmasettings[3][4];
   DMAChannel   _dmatx;
   uint8_t      _cnt_dma_settings;   // how many do we need for this display?
   #elif defined(__IMXRT1062__)  // Teensy 4.x

--- a/ST7735_t3.h
+++ b/ST7735_t3.h
@@ -26,7 +26,7 @@
 #ifndef DISABLE_ST77XX_FRAMEBUFFER
 #if defined(__MK64FX512__) || defined(__MK66FX1M0__)
 #define ENABLE_ST77XX_FRAMEBUFFER
-#elif defined(__IMXRT1052__) || defined(__IMXRT1062__)
+#elif defined(__IMXRT1062__)
 #define ENABLE_ST77XX_FRAMEBUFFER
 #endif
 // Lets allow the user to define if they want T3.2 to enable frame buffer.
@@ -129,6 +129,19 @@
 #define ST77XX_YELLOW     0xFFE0
 #define ST77XX_ORANGE     0xFC00
 
+
+#if defined(__IMXRT1062__)  // Teensy 4.x
+// Also define these in lower memory so as to make sure they are not cached...
+// try work around DMA memory cached.  So have a couple of buffers we copy frame buffer into
+// as to move it out of the memory that is cached...
+#define ST77XX_DMA_BUFFER_SIZE 512
+typedef struct {
+  DMASetting      _dmasettings[2];
+  DMAChannel      _dmatx;
+  uint16_t        _dma_buffer1[ST77XX_DMA_BUFFER_SIZE] __attribute__ ((aligned(4)));
+  uint16_t        _dma_buffer2[ST77XX_DMA_BUFFER_SIZE] __attribute__ ((aligned(4)));  
+} ST7735DMA_Data;
+#endif
 
 
 class ST7735_t3 : public Adafruit_GFX {
@@ -263,7 +276,7 @@ class ST7735_t3 : public Adafruit_GFX {
 
 
 #endif
-#if defined(__IMXRT1052__) || defined(__IMXRT1062__)  // Teensy 4.x
+#if defined(__IMXRT1062__)  // Teensy 4.x
   SPIClass *_pspi = nullptr;
   uint8_t   _spi_num;          // Which buss is this spi on? 
   IMXRT_LPSPI_t *_pimxrt_spi = nullptr;
@@ -385,18 +398,14 @@ volatile uint8_t *dataport, *clkport, *csport, *rsport;
   DMASetting   _dmasettings[4];
   DMAChannel   _dmatx;
   uint8_t      _cnt_dma_settings;   // how many do we need for this display?
-  #elif defined(__IMXRT1052__) || defined(__IMXRT1062__)  // Teensy 4.x
+  #elif defined(__IMXRT1062__)  // Teensy 4.x
+  static ST7735DMA_Data _dma_data[3];   // one structure for each SPI buss... 
   // try work around DMA memory cached.  So have a couple of buffers we copy frame buffer into
   // as to move it out of the memory that is cached...
-  DMASetting   _dmasettings[2];
-  DMAChannel   _dmatx;
   volatile    uint32_t _dma_pixel_index = 0;
   volatile uint16_t _dma_sub_frame_count = 0; // Can return a frame count...
   uint16_t          _dma_buffer_size;   // the actual size we are using <= DMA_BUFFER_SIZE;
   uint16_t          _dma_cnt_sub_frames_per_frame;  
-  static const uint16_t    DMA_BUFFER_SIZE = 512;
-  uint16_t          _dma_buffer1[DMA_BUFFER_SIZE] __attribute__ ((aligned(4)));
-  uint16_t          _dma_buffer2[DMA_BUFFER_SIZE] __attribute__ ((aligned(4)));
   uint32_t      _spi_fcr_save;    // save away previous FCR register value
 
   #elif defined(__MK64FX512__)

--- a/ST7735_t3.h
+++ b/ST7735_t3.h
@@ -154,7 +154,7 @@ class ST7735_t3 : public Adafruit_GFX {
   void     initB(void),                             // for ST7735B displays
            initR(uint8_t options = INITR_GREENTAB), // for ST7735R
            setAddrWindow(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1),
-           pushColor(uint16_t color),
+           pushColor(uint16_t color, boolean last_pixel=false),
            fillScreen(uint16_t color),
            drawPixel(int16_t x, int16_t y, uint16_t color),
            drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color),


### PR DESCRIPTION
Paul,

This is a couple of different things.  

Probably the most important is that some of the key member variables are initialized.  Did not show up with test sketches as if you do the normal like
```
ST7735_t3 tft = ST7735(cs, dc, rst);
```
As the memory in the DTCM for variables is either initialized or zeroed and so it worked fine.  However uncanny eyes instead does something like:
```
ST7735_t3 *my_tft = new ST7735(cs, dc, rst);
```
So the object is created up on the heap and not initialized.  This caused issues.  Like the logical pointer to frame buffer was not nullptr so code assumed it was active and stored data off of this random pointer... 

In addition to this.  When doing DMA stuff, I could not get the code to work if the DMA structures where stored up in the OCRAM(heap).  Things like DMAChannel and DMASettings.  Also code currently copies portions of the Frame buffer to smaller sections that I can make sure the memory has the right values (Memory vs Cache values)... So have the class allocate space for DMA info for 3 objects (as there are 3 SPI busses)... 

Would prefer to have system function to try to allocate lower memory instead as some form of system function, but this should work until then.

