### PR TITLE
T4.x - Will have multiple CS pins with different indexes on SPI object

### DIFF
--- a/ST7735_t3.cpp
+++ b/ST7735_t3.cpp
@@ -1379,13 +1379,13 @@ void ST7735_t3::fillTriangle ( int16_t x0, int16_t y0,
 
   // Sort coordinates by Y order (y2 >= y1 >= y0)
   if (y0 > y1) {
-    swap(y0, y1); swap(x0, x1);
+    st7735_swap(y0, y1); st7735_swap(x0, x1);
   }
   if (y1 > y2) {
-    swap(y2, y1); swap(x2, x1);
+    st7735_swap(y2, y1); st7735_swap(x2, x1);
   }
   if (y0 > y1) {
-    swap(y0, y1); swap(x0, x1);
+    st7735_swap(y0, y1); st7735_swap(x0, x1);
   }
 
   if(y0 == y2) { // Handle awkward all-on-same-line case as its own thing
@@ -1426,7 +1426,7 @@ void ST7735_t3::fillTriangle ( int16_t x0, int16_t y0,
     a = x0 + (x1 - x0) * (y - y0) / (y1 - y0);
     b = x0 + (x2 - x0) * (y - y0) / (y2 - y0);
     */
-    if(a > b) swap(a,b);
+    if(a > b) st7735_swap(a,b);
     drawFastHLine(a, y, b-a+1, color);
   }
 
@@ -1443,7 +1443,7 @@ void ST7735_t3::fillTriangle ( int16_t x0, int16_t y0,
     a = x1 + (x2 - x1) * (y - y1) / (y2 - y1);
     b = x0 + (x2 - x0) * (y - y0) / (y2 - y0);
     */
-    if(a > b) swap(a,b);
+    if(a > b) st7735_swap(a,b);
     drawFastHLine(a, y, b-a+1, color);
   }
 }
@@ -1580,12 +1580,12 @@ void ST7735_t3::drawLine(int16_t x0, int16_t y0,
 
 	bool steep = abs(y1 - y0) > abs(x1 - x0);
 	if (steep) {
-		swap(x0, y0);
-		swap(x1, y1);
+		st7735_swap(x0, y0);
+		st7735_swap(x1, y1);
 	}
 	if (x0 > x1) {
-		swap(x0, x1);
-		swap(y0, y1);
+		st7735_swap(x0, x1);
+		st7735_swap(y0, y1);
 	}
 
 	int16_t dx, dy;

--- a/ST7735_t3.h
+++ b/ST7735_t3.h
@@ -163,8 +163,8 @@ typedef struct {
 #endif // _GFXFONT_H_
 
 
-#ifndef swap
-#define swap(a, b) { typeof(a) t = a; a = b; b = t; }
+#ifndef st7735_swap
+#define st7735_swap(a, b) { typeof(a) t = a; a = b; b = t; }
 #endif
 
 #ifdef __cplusplus

--- a/ST7735_t3.h
+++ b/ST7735_t3.h
@@ -508,6 +508,8 @@ class ST7735_t3 : public Print
   SPIClass::SPI_Hardware_t *_spi_hardware;
   uint8_t _pending_rx_count = 0;
   uint32_t _spi_tcr_current = 0; 
+  uint32_t _tcr_dc_assert;
+  uint32_t _tcr_dc_not_assert;
 
 
   void DIRECT_WRITE_LOW(volatile uint32_t * base, uint32_t mask)  __attribute__((always_inline)) {
@@ -540,6 +542,7 @@ class ST7735_t3 : public Print
 
   inline void beginSPITransaction() {
     if (hwSPI) _pspi->beginTransaction(_spiSettings);
+    if (!_dcport) _spi_tcr_current = _pimxrt_spi->TCR;  // Only if DC is on hardware CS 
     if (_csport)DIRECT_WRITE_LOW(_csport, _cspinmask);
   }
 

--- a/examples/TFT_String_Align/TFT_String_Align.ino
+++ b/examples/TFT_String_Align/TFT_String_Align.ino
@@ -17,7 +17,7 @@ BR_DATUM = Bottom right
 #include <SPI.h>
 #include <ST7735_t3.h> // Hardware-specific library
 #include <ST7789_t3.h> // Hardware-specific library
-#include <ST7735_t3_font_Arial.h>
+#include <st7735_t3_font_Arial.h>
 
 
 #define TFT_MISO  1


### PR DESCRIPTION
The new T4.1 will have more CS pins on SPI object.   These have different SPI index values that will confuse current code that assumes  CS index of 0...

T4.1 SPI1 also has two MISO1 pins, and 2 CS0 pins, but these don't cause issues for this driver

@PaulStoffregen  - Note, to notice the difference will need my SPI PR pulled in as well 