### PR TITLE
Fix double promotion on T4

### DIFF
--- a/ST7735_t3.cpp
+++ b/ST7735_t3.cpp
@@ -3175,8 +3175,10 @@ void ST7735_t3::drawGFXFontChar(unsigned int c) {
     GFXglyph *glyph  = gfxFont->glyph + (c - first);
     uint8_t   w     = glyph->width,
               h     = glyph->height;
-    if((w == 0) || (h == 0))  return;  // Is there an associated bitmap?
-
+			  
+    // wonder if we should look at xo, yo instead?         
+    if((w == 0 ||  h == 0)  && (c != 32))   return;  // Is there an associated bitmap?
+	
     int16_t xo = glyph->xOffset; // sic
     int16_t yo = glyph->yOffset + gfxFont->yAdvance/2;
 

--- a/ST7735_t3.cpp
+++ b/ST7735_t3.cpp
@@ -1779,7 +1779,7 @@ int16_t ST7735_t3::drawFloat(float floatNumber, int dp, int poX, int poY)
   if (dp > 7) dp = 7; // Limit the size of decimal portion
 
   // Adjust the rounding value
-  for (uint8_t i = 0; i < dp; ++i) rounding /= 10.0;
+  for (uint8_t i = 0; i < dp; ++i) rounding /= 10.0f;
 
   if (floatNumber < -rounding)    // add sign, avoid adding - sign to 0.0!
   {


### PR DESCRIPTION
This is based on the patch to the ILI9341_t3 lib that Frank B issued to @KurtE  ILI341_t3n lib (https://github.com/KurtE/ILI9341_t3n/pull/30).  Keeping changes consistent between libs.  Same change also made to the ILI9488_t3 library as well.

EDIT: this also fixes a issue with GFX font spacing. see thread https://forum.pjrc.com/threads/59880-In-ST7735_t3-tft-Print-and-tft-Println-do-not-print-spaces