### PR TITLE
GFX Font - If GFX is included then include their font file definition.

### DIFF
--- a/ST7735_t3.h
+++ b/ST7735_t3.h
@@ -139,6 +139,10 @@
 #define ST7735_t3_font_t ILI9341_t3_font_t
 
 // Lets see about supporting Adafruit fonts as well?
+#if __has_include(<gfxfont.h>)
+  #include <gfxfont.h>
+#endif
+
 #ifndef _GFXFONT_H_
 #define _GFXFONT_H_
 


### PR DESCRIPTION
This handles the cases where user has older or newer GFX fonts

We just use their font definition and as such it does not matter if they are using a version whoes start and end indexes are 8 bits or 16 bits.