### PR TITLE
T-LC - Speedup - Double buffer, 16 bit writes

### DIFF
--- a/ST7735_t3.cpp
+++ b/ST7735_t3.cpp
@@ -3935,7 +3935,7 @@ void	ST7735_t3::initDMASettings(void)
 	// to remove tearing and the like...I know with 256 it will be either 256 or 248...
 	_dma_buffer_size = ST77XX_DMA_BUFFER_SIZE;
 	_dma_cnt_sub_frames_per_frame = (_count_pixels) / _dma_buffer_size;
-	while ((_dma_cnt_sub_frames_per_frame * _dma_buffer_size) != (_count_pixels)) {
+	while ((uint32_t)(_dma_cnt_sub_frames_per_frame * _dma_buffer_size) != (_count_pixels)) {
 		_dma_buffer_size--;
 		_dma_cnt_sub_frames_per_frame = (_count_pixels) / _dma_buffer_size;		
 	}

--- a/ST7735_t3.cpp
+++ b/ST7735_t3.cpp
@@ -388,14 +388,68 @@ void ST7735_t3::setBitrate(uint32_t n)
 /***************************************************************/
 #elif defined(__MKL26Z64__)
 
+void ST7735_t3::waitTransmitComplete()  {
+	if(!_pkinetisl_spi) return; // Software SPI don't do anything
+	while (_data_sent_not_completed) {
+		uint16_t timeout_count = 0xff; // hopefully enough 
+		while (!(_pkinetisl_spi->S & SPI_S_SPRF) && timeout_count--) ; // wait 
+		uint8_t d __attribute__((unused));
+		d = _pkinetisl_spi->DL;
+		d = _pkinetisl_spi->DH;
+		_data_sent_not_completed--; // We hopefully received our data...
+	}
+}
+
+void ST7735_t3::spiwrite16(uint16_t data)  {
+	if (_pkinetisl_spi) {
+		if (!(_pkinetisl_spi->C2 & SPI_C2_SPIMODE)) {
+			// Wait to change modes until any pending output has been done.
+			waitTransmitComplete();
+			_pkinetisl_spi->C2 = SPI_C2_SPIMODE; // make sure 8 bit mode.
+		}
+		uint8_t s;
+		do {
+			s = _pkinetisl_spi->S;
+			 // wait if output buffer busy.
+			// Clear out buffer if there is something there...
+			if  ((s & SPI_S_SPRF)) {
+				uint8_t d __attribute__((unused));
+				d = _pkinetisl_spi->DL;
+				d = _pkinetisl_spi->DH;
+				_data_sent_not_completed--; 	// let system know we sent something	
+			}
+
+		} while (!(s & SPI_S_SPTEF) || (s & SPI_S_SPRF));
+
+		_pkinetisl_spi->DL = data; 		// output low byte
+		_pkinetisl_spi->DH = data >> 8; // output high byte
+		_data_sent_not_completed++; 	// let system know we sent something	
+	} else {
+		// call bitbang functions	
+		spiwrite(data >> 8);
+		spiwrite(data);
+	}
+}
 
 inline void ST7735_t3::spiwrite(uint8_t c)
 {
 //Serial.println(c, HEX);
-	if (hwSPI) {
-		SPI.transfer(c);
-	} else if (hwSPI1) {
-		SPI1.transfer(c);
+	if (_pkinetisl_spi) {
+		if (_pkinetisl_spi->C2 & SPI_C2_SPIMODE) {
+			// Wait to change modes until any pending output has been done.
+			waitTransmitComplete();
+			_pkinetisl_spi->C2 = 0; // make sure 8 bit mode.
+		}
+		while (!(_pkinetisl_spi->S & SPI_S_SPTEF)) ; // wait if output buffer busy.
+		// Clear out buffer if there is something there...
+		if  ((_pkinetisl_spi->S & SPI_S_SPRF)) {
+			uint8_t d __attribute__((unused));
+			d = _pkinetisl_spi->DL;
+			_data_sent_not_completed--;
+		} 
+		_pkinetisl_spi->DL = c; // output byte
+		_data_sent_not_completed++; // let system know we sent something	
+
 	} else {
 		// Fast SPI bitbang swiped from LPD8806 library
 		for(uint8_t bit = 0x80; bit; bit >>= 1) {
@@ -409,39 +463,42 @@ inline void ST7735_t3::spiwrite(uint8_t c)
 
 void ST7735_t3::writecommand(uint8_t c)
 {
-	*rsport &= ~rspinmask;
+	setCommandMode();
 	spiwrite(c);
 }
 void ST7735_t3::writecommand_last(uint8_t c)
 {
-	*rsport &= ~rspinmask;
+	setCommandMode();
 	spiwrite(c);
+	waitTransmitComplete();
 }
 
 void ST7735_t3::writedata(uint8_t c)
 {
-	*rsport |=  rspinmask;
+	setDataMode();
 	spiwrite(c);
 } 
 
 void ST7735_t3::writedata_last(uint8_t c)
 {
-	*rsport |=  rspinmask;
+	setDataMode();
 	spiwrite(c);
+	waitTransmitComplete();
 } 
 
 void ST7735_t3::writedata16(uint16_t d)
 {
-	*rsport |=  rspinmask;
-	spiwrite(d >> 8);
-	spiwrite(d);
+	setDataMode();
+	spiwrite16(d);
 } 
 
 void ST7735_t3::writedata16_last(uint16_t d)
 {
-	*rsport |=  rspinmask;
-	spiwrite(d >> 8);
-	spiwrite(d);
+	setDataMode();
+	spiwrite16(d);
+	waitTransmitComplete();
+	_pkinetisl_spi->C2 = 0; // Set back to 8 bit mode...
+	_pkinetisl_spi->S;	// Read in the status;
 } 
 
 void ST7735_t3::setBitrate(uint32_t n)
@@ -826,6 +883,7 @@ void ST7735_t3::commonInit(const uint8_t *cmdList, uint8_t mode)
 
     // Teensy LC
 #elif defined(__MKL26Z64__)
+	// BUGBUG:: cleanup use SPI tables to confirm, like above. 
 	hwSPI1 = false;
 	if (_sid == (uint8_t)-1) _sid = 11;
 	if (_sclk == (uint8_t)-1) _sclk = 13;
@@ -855,11 +913,14 @@ void ST7735_t3::commonInit(const uint8_t *cmdList, uint8_t mode)
 		if (_sclk == 14) SPI.setSCK(14);
 		if (_sid == 7) SPI.setMOSI(7);
 		SPI.begin();
+		_pkinetisl_spi = &KINETISL_SPI0;
 	} else if(hwSPI1) { // Using hardware SPI
 		SPI1.setSCK(_sclk);
 		SPI1.setMOSI(_sid);
 		SPI1.begin();
+		_pkinetisl_spi = &KINETISL_SPI1;
 	} else {
+		_pkinetisl_spi = nullptr;
 		pinMode(_sclk, OUTPUT);
 		pinMode(_sid , OUTPUT);
 		clkport     = portOutputRegister(digitalPinToPort(_sclk));
@@ -871,6 +932,9 @@ void ST7735_t3::commonInit(const uint8_t *cmdList, uint8_t mode)
 	}
 	// toggle RST low to reset; CS low so it'll listen to us
 	*csport &= ~cspinmask;
+
+	_dcpinAsserted = 2;	// Should be forced on next call
+	_data_sent_not_completed = 0;
 
 #endif
 	// BUGBUG

--- a/examples/spitftbitmap/spitftbitmap.ino
+++ b/examples/spitftbitmap/spitftbitmap.ino
@@ -1,13 +1,13 @@
 /***************************************************
   This is an example sketch for the Adafruit 1.8" SPI display.
 
-This library works with the Adafruit 1.8" TFT Breakout w/SD card
+  This library works with the Adafruit 1.8" TFT Breakout w/SD card
   ----> http://www.adafruit.com/products/358
-The 1.8" TFT shield
+  The 1.8" TFT shield
   ----> https://www.adafruit.com/product/802
-The 1.44" TFT breakout
+  The 1.44" TFT breakout
   ----> https://www.adafruit.com/product/2088
-as well as Adafruit raw 1.8" TFT display
+  as well as Adafruit raw 1.8" TFT display
   ----> http://www.adafruit.com/products/618
 
   Check out the links above for our tutorials and wiring diagrams
@@ -21,10 +21,12 @@ as well as Adafruit raw 1.8" TFT display
   MIT license, all text above must be included in any redistribution
  ****************************************************/
 
-#include <Adafruit_GFX.h>    // Core graphics library
-#include <ST7735_t3.h> // Hardware-specific library
+#include <ST7735_t3.h>    // Hardware-specific library
+#include <ST7789_t3.h>    // Hardware-specific library
 #include <SPI.h>
 #include <SD.h>
+
+//#define IMAGE_COLORS_BGR // set if you colors are reversed
 
 // This Teensy3 native optimized version requires specific pins
 //
@@ -35,24 +37,48 @@ as well as Adafruit raw 1.8" TFT display
 #define TFT_RST   8  // RST can use any pin
 #define SD_CS     4  // CS for SD card, can use any pin
 
+// Use one or the other
 ST7735_t3 tft = ST7735_t3(TFT_CS, TFT_DC, TFT_MOSI, TFT_SCLK, TFT_RST);
+//ST7789_t3 tft = ST7789_t3(TFT_CS, TFT_DC, TFT_MOSI, TFT_SCLK, TFT_RST);
 
 void setup(void) {
   pinMode(SD_CS, INPUT_PULLUP);  // keep SD CS high when not using SD card
   Serial.begin(9600);
 
-  // Use this initializer if you're using a 1.8" TFT
-  tft.initR(INITR_BLACKTAB);
-  // Use this initializer (uncomment) if you're using a 1.44" TFT
-  //tft.initR(INITR_144GREENTAB);
+  // only uncomment one of these display initializers.
+  // ST7735 - More options mentioned in examples for st7735_t3 library
+  //tft.initR(INITR_BLACKTAB); // if you're using a 1.8" TFT 128x160 displays
+  tft.initR(INITR_144GREENTAB); // if you're using a 1.44" TFT (128x128)
+  //tft.initR(INITR_MINI160x80);  //if you're using a .96" TFT(160x80)
 
+  // ST7789
+  //tft.init(240, 240);           // initialize a ST7789 chip, 240x240 pixels
+  //tft.init(240, 320);           // Init ST7789 2.0" 320x240
+  //tft.init(135, 240);             // Init ST7789 1.4" 135x240
+  //tft.init(240, 240, SPI_MODE2);    // clones Init ST7789 240x240 no CS
+  tft.setTextColor(ST77XX_BLACK);
+  tft.setTextSize(2);
+  tft.fillScreen(ST77XX_RED);
+  tft.setCursor(ST7735_t3::CENTER, ST7735_t3::CENTER);
+  tft.print("RED");
+  delay(500);
+  tft.fillScreen(ST77XX_GREEN);
+  tft.setCursor(ST7735_t3::CENTER, ST7735_t3::CENTER);
+  tft.print("GREEN");
+  delay(500);
+  tft.fillScreen(ST77XX_BLUE);
+  tft.setCursor(ST7735_t3::CENTER, ST7735_t3::CENTER);
+  tft.print("BLUE");
+  delay(500);
+  tft.fillScreen(ST77XX_BLACK);
+  tft.setCursor(0,0);
   Serial.print("Initializing SD card...");
   if (!SD.begin(SD_CS)) {
     Serial.println("failed!");
     tft.fillScreen(ST7735_BLACK);
-    tft.setCursor(5, tft.height()/2 - 6);
+    tft.setCursor(5, tft.height() / 2 - 6);
     tft.print("Unable to access");
-    tft.setCursor(32, tft.height()/2 + 6);
+    tft.setCursor(32, tft.height() / 2 + 6);
     tft.print("SD card");
     while (1) {
       // do nothing if SD card not working
@@ -64,14 +90,14 @@ void setup(void) {
 }
 
 void loop() {
-// uncomment these lines to draw bitmaps in different locations/rotations!
-/*
-  tft.fillScreen(ST7735_BLACK); // Clear display
-  for (int i=0; i<4; i++)       // Draw 4 parrots
-    bmpDraw("parrot.bmp", tft.width() / 4 * i, tft.height() / 4 * i);
-  delay(1000);
-  tft.setRotation(tft.getRotation() + 1); // Inc rotation 90 degrees
-*/
+  // uncomment these lines to draw bitmaps in different locations/rotations!
+  /*
+    tft.fillScreen(ST7735_BLACK); // Clear display
+    for (int i=0; i<4; i++)       // Draw 4 parrots
+      bmpDraw("parrot.bmp", tft.width() / 4 * i, tft.height() / 4 * i);
+    delay(1000);
+    tft.setRotation(tft.getRotation() + 1); // Inc rotation 90 degrees
+  */
 }
 
 // This function opens a Windows Bitmap (BMP) file and
@@ -93,7 +119,7 @@ void bmpDraw(const char *filename, uint8_t x, uint16_t y) {
   uint8_t  bmpDepth;              // Bit depth (currently must be 24)
   uint32_t bmpImageoffset;        // Start of image data in file
   uint32_t rowSize;               // Not always = bmpWidth; may have padding
-  uint8_t  sdbuffer[3*BUFFPIXEL]; // pixel buffer (R+G+B per pixel)
+  uint8_t  sdbuffer[3 * BUFFPIXEL]; // pixel buffer (R+G+B per pixel)
   uint16_t buffidx = sizeof(sdbuffer); // Current position in sdbuffer
   boolean  goodBmp = false;       // Set to true on valid header parse
   boolean  flip    = true;        // BMP is stored bottom-to-top
@@ -103,7 +129,7 @@ void bmpDraw(const char *filename, uint8_t x, uint16_t y) {
 
   uint16_t awColors[320];  // hold colors for one row at a time...
 
-  if((x >= tft.width()) || (y >= tft.height())) return;
+  if ((x >= tft.width()) || (y >= tft.height())) return;
 
   Serial.println();
   Serial.print(F("Loading image '"));
@@ -115,18 +141,18 @@ void bmpDraw(const char *filename, uint8_t x, uint16_t y) {
   if (!bmpFile) {
     Serial.print("File not found");
     tft.fillScreen(ST7735_BLACK);
-    tft.setCursor(12, tft.height()/2 - 12);
+    tft.setCursor(12, tft.height() / 2 - 12);
     tft.print("Unable to");
-    tft.setCursor(12, tft.height()/2 - 0);
+    tft.setCursor(12, tft.height() / 2 - 0);
     tft.print("read file: ");
-    tft.setCursor(12, tft.height()/2 + 12);
+    tft.setCursor(12, tft.height() / 2 + 12);
     tft.setTextColor(ST7735_YELLOW);
     tft.print(filename);
     return;
   }
 
   // Parse BMP header
-  if(read16(bmpFile) == 0x4D42) { // BMP signature
+  if (read16(bmpFile) == 0x4D42) { // BMP signature
     Serial.print(F("File size: ")); Serial.println(read32(bmpFile));
     (void)read32(bmpFile); // Read & ignore creator bytes
     bmpImageoffset = read32(bmpFile); // Start of image data
@@ -135,10 +161,10 @@ void bmpDraw(const char *filename, uint8_t x, uint16_t y) {
     Serial.print(F("Header size: ")); Serial.println(read32(bmpFile));
     bmpWidth  = read32(bmpFile);
     bmpHeight = read32(bmpFile);
-    if(read16(bmpFile) == 1) { // # planes -- must be '1'
+    if (read16(bmpFile) == 1) { // # planes -- must be '1'
       bmpDepth = read16(bmpFile); // bits per pixel
       Serial.print(F("Bit Depth: ")); Serial.println(bmpDepth);
-      if((bmpDepth == 24) && (read32(bmpFile) == 0)) { // 0 = uncompressed
+      if ((bmpDepth == 24) && (read32(bmpFile) == 0)) { // 0 = uncompressed
 
         goodBmp = true; // Supported BMP format -- proceed!
         Serial.print(F("Image size: "));
@@ -151,7 +177,7 @@ void bmpDraw(const char *filename, uint8_t x, uint16_t y) {
 
         // If bmpHeight is negative, image is in top-down order.
         // This is not canon but has been observed in the wild.
-        if(bmpHeight < 0) {
+        if (bmpHeight < 0) {
           bmpHeight = -bmpHeight;
           flip      = false;
         }
@@ -159,10 +185,10 @@ void bmpDraw(const char *filename, uint8_t x, uint16_t y) {
         // Crop area to be loaded
         w = bmpWidth;
         h = bmpHeight;
-        if((x+w-1) >= tft.width())  w = tft.width()  - x;
-        if((y+h-1) >= tft.height()) h = tft.height() - y;
+        if ((x + w - 1) >= tft.width())  w = tft.width()  - x;
+        if ((y + h - 1) >= tft.height()) h = tft.height() - y;
 
-        for (row=0; row<h; row++) { // For each scanline...
+        for (row = 0; row < h; row++) { // For each scanline...
 
           // Seek to start of scan line.  It might seem labor-
           // intensive to be doing this on every line, but this
@@ -170,16 +196,16 @@ void bmpDraw(const char *filename, uint8_t x, uint16_t y) {
           // and scanline padding.  Also, the seek only takes
           // place if the file position actually needs to change
           // (avoids a lot of cluster math in SD library).
-          if(flip) // Bitmap is stored bottom-to-top order (normal BMP)
+          if (flip) // Bitmap is stored bottom-to-top order (normal BMP)
             pos = bmpImageoffset + (bmpHeight - 1 - row) * rowSize;
           else     // Bitmap is stored top-to-bottom
             pos = bmpImageoffset + row * rowSize;
-          if(bmpFile.position() != pos) { // Need seek?
+          if (bmpFile.position() != pos) { // Need seek?
             bmpFile.seek(pos);
             buffidx = sizeof(sdbuffer); // Force buffer reload
           }
 
-          for (col=0; col<w; col++) { // For each pixel...
+          for (col = 0; col < w; col++) { // For each pixel...
             // Time to read more pixel data?
             if (buffidx >= sizeof(sdbuffer)) { // Indeed
               bmpFile.read(sdbuffer, sizeof(sdbuffer));
@@ -187,10 +213,16 @@ void bmpDraw(const char *filename, uint8_t x, uint16_t y) {
             }
 
             // Convert pixel from BMP to TFT format, push to display
+            #ifdef IMAGE_COLORS_BGR
             b = sdbuffer[buffidx++];
             g = sdbuffer[buffidx++];
             r = sdbuffer[buffidx++];
-            awColors[col] = tft.Color565(r,g,b);
+            #else
+            r = sdbuffer[buffidx++];
+            g = sdbuffer[buffidx++];
+            b = sdbuffer[buffidx++];
+            #endif
+            awColors[col] = tft.Color565(r, g, b);
           } // end pixel
           tft.writeRect(0, row, w, 1, awColors);
         } // end scanline
@@ -202,7 +234,7 @@ void bmpDraw(const char *filename, uint8_t x, uint16_t y) {
   }
 
   bmpFile.close();
-  if(!goodBmp) Serial.println(F("BMP format not recognized."));
+  if (!goodBmp) Serial.println(F("BMP format not recognized."));
 }
 
 // These read 16- and 32-bit types from the SD card file.
@@ -224,4 +256,3 @@ uint32_t read32(File f) {
   ((uint8_t *)&result)[3] = f.read(); // MSB
   return result;
 }
-


### PR DESCRIPTION
@PaulStoffregen (@mjs513 and @defragster) - As I wondering yesterday if it makes sense to spend any time on T-LC with some of our drivers, I thought I would do a quick check on these drivers.  We already had them working with this library, but all transfers to screen went through SPI.transfer (did not even use 16 bit transfers).

Before everything done with SPI.transfer, or SPI1.transfer

Instead go to registers and try to double buffer as much as possible.

Now when we write 16 bit values like a color, it switches the port to 16 bit mode and pushes both such as to reduce the gap between outputs.

There is more details of changes in speed up in the forum thread: https://forum.pjrc.com/threads/61705-ST7735_t3-ST7789_t3-LC-Support-Speedups.  Note: all of my testing of it was with an Adafruit 2" St7789 320x240 or same as ILI9341. 

Time to do fillscreen was improved: 369 to 248

A version of he graphic test, that outputs timings for the different tests (actually it also cycles through each rotation).
The Rotation 0 started off with:
```
tftPrintTest: 2293
testlines: 3478
tftPrintTest: 521
testdrawrects: 464
tftPrintTest: 4255
testfill/drawcircles: 1327
testroundrects: 850
testtriangles: 511
mediabuttons: 1512
```
To:
```
tftPrintTest: 2049
testlines: 2998
tftPrintTest: 352
testdrawrects: 314
tftPrintTest: 2864
testfill/drawcircles: 1136
testroundrects: 616
testtriangles: 382
mediabuttons: 1364
```
Which I think is pretty good, but again if LC is winding down, then not sure if these changes are needed? 