### PR TITLE
ST7735: Do not call TCR code if no hwSPI

### DIFF
--- a/ST7735_t3.cpp
+++ b/ST7735_t3.cpp
@@ -879,7 +879,9 @@ void ST7735_t3::commonInit(const uint8_t *cmdList, uint8_t mode)
 		_tcr_dc_assert = LPSPI_TCR_PCS(0);
     	_tcr_dc_not_assert = LPSPI_TCR_PCS(1);
 	}
-	maybeUpdateTCR(_tcr_dc_not_assert | LPSPI_TCR_FRAMESZ(7));
+
+	if (hwSPI)
+		maybeUpdateTCR(_tcr_dc_not_assert | LPSPI_TCR_FRAMESZ(7));
 
     // Teensy LC
 #elif defined(__MKL26Z64__)


### PR DESCRIPTION
If using a pure SW (GPIO) SPI connection, a call to
maybeUpdateTCR was still being made, which can hang up as
we are not on a hw SPI bus.

Predicate the call with a check for hwSPI, as is done in other
places already.

Fixes: #22

Signed-off-by: Graham Whaley <graham.whaley@gmail.com>