### PR TITLE
Pixel function - check clip rectangle...

### DIFF
--- a/ST7735_t3.h
+++ b/ST7735_t3.h
@@ -772,7 +772,7 @@ class ST7735_t3 : public Print
 	    x+=_originx;
 	    y+=_originy;
 
-	  	//if((x < _displayclipx1) ||(x >= _displayclipx2) || (y < _displayclipy1) || (y >= _displayclipy2)) return;
+	  	if((x < _displayclipx1) ||(x >= _displayclipx2) || (y < _displayclipy1) || (y >= _displayclipy2)) return;
 
 		#ifdef ENABLE_ST77XX_FRAMEBUFFER
 	  	if (_use_fbtft) {


### PR DESCRIPTION
The code to check the clip rectangle was commented out.

There is a forum thread: https://forum.pjrc.com/threads/65791-Teensy4-0-ST7735-Freezing-when-using-frame-buffer?p=266280#post266280

Where the user was calling drawLine with two negative values and one of those values turned out to dall the pixel function with a bogus negative value, and as we did not check the bounds it wrote over something which crashed the sketch