### PR TITLE
Fix Text center/charbounds issue like ili... drivers

### DIFF
--- a/ST7735_t3.cpp
+++ b/ST7735_t3.cpp
@@ -2062,10 +2062,10 @@ size_t ST7735_t3::write(const uint8_t *buffer, size_t size)
 	  	//Serial.printf("_fontwrite bounds: %d %d %u %u\n", x, y, strngWidth, strngHeight);
 	  	// Note we may want to play with the x ane y returned if they offset some
 		if (_center_x_text && strngWidth > 0){//Avoid operations for strngWidth = 0
-			cursor_x -= ((x + strngWidth) / 2);
+      		cursor_x -= (x + strngWidth / 2);
 		}
 		if (_center_y_text && strngHeight > 0){//Avoid operations for strngWidth = 0
-			cursor_y -= ((y + strngHeight) / 2);
+		    cursor_y -= (y + strngHeight / 2);
 		}
 		_center_x_text = false;
 		_center_y_text = false;
@@ -3061,7 +3061,7 @@ void ST7735_t3::charBounds(char c, int16_t *x, int16_t *y,
 
             int16_t
                     x1 = *x + xoffset,
-                    y1 = *y + yoffset,
+                    y1 = *y + font->cap_height - height - yoffset,
                     x2 = x1 + width,
                     y2 = y1 + height;
 

--- a/ST7735_t3.cpp
+++ b/ST7735_t3.cpp
@@ -1337,6 +1337,11 @@ void ST7735_t3::readRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t *p
 // Now lets see if we can writemultiple pixels
 void ST7735_t3::writeRect(int16_t x, int16_t y, int16_t w, int16_t h, const uint16_t *pcolors)
 {
+	if (x == CENTER)
+		x = (_width - w) / 2;
+	if (y == CENTER)
+		y = (_height - h) / 2;
+
 	x+=_originx;
 	y+=_originy;
 

--- a/ST7735_t3.h
+++ b/ST7735_t3.h
@@ -370,6 +370,46 @@ class ST7735_t3 : public Print
   void writeSubImageRectBytesReversed(int16_t x, int16_t y, int16_t w, int16_t h, 
                         int16_t image_offset_x, int16_t image_offset_y, int16_t image_width, int16_t image_height, 
                         const uint16_t *pcolors);
+  // writeRect8BPP -  write 8 bit per pixel paletted bitmap
+  //          bitmap data in array at pixels, one byte per
+  //pixel
+  //          color palette data in array at palette
+  void writeRect8BPP(int16_t x, int16_t y, int16_t w, int16_t h,
+                     const uint8_t *pixels, const uint16_t *palette);
+
+  // writeRect4BPP -  write 4 bit per pixel paletted bitmap
+  //          bitmap data in array at pixels, 4 bits per
+  //pixel
+  //          color palette data in array at palette
+  //          width must be at least 2 pixels
+  void writeRect4BPP(int16_t x, int16_t y, int16_t w, int16_t h,
+                     const uint8_t *pixels, const uint16_t *palette);
+
+  // writeRect2BPP -  write 2 bit per pixel paletted bitmap
+  //          bitmap data in array at pixels, 4 bits per
+  //pixel
+  //          color palette data in array at palette
+  //          width must be at least 4 pixels
+  void writeRect2BPP(int16_t x, int16_t y, int16_t w, int16_t h,
+                     const uint8_t *pixels, const uint16_t *palette);
+
+  // writeRect1BPP -  write 1 bit per pixel paletted bitmap
+  //          bitmap data in array at pixels, 4 bits per
+  //pixel
+  //          color palette data in array at palette
+  //          width must be at least 8 pixels
+  void writeRect1BPP(int16_t x, int16_t y, int16_t w, int16_t h,
+                     const uint8_t *pixels, const uint16_t *palette);
+
+  // writeRectNBPP -  write N(1, 2, 4, 8) bit per pixel paletted bitmap
+  //          bitmap data in array at pixels
+  //  Currently writeRect1BPP, writeRect2BPP, writeRect4BPP use this to do all
+  //  of the work.
+  //
+  void writeRectNBPP(int16_t x, int16_t y, int16_t w, int16_t h,
+                     uint8_t bits_per_pixel, const uint8_t *pixels,
+                     const uint16_t *palette);
+
 
 // Frame buffer support
 #ifdef ENABLE_ST77XX_FRAMEBUFFER

--- a/ST7735_t3.h
+++ b/ST7735_t3.h
@@ -364,6 +364,12 @@ class ST7735_t3 : public Print
   */
   // Useful methods added from ili9341_t3 
   void writeRect(int16_t x, int16_t y, int16_t w, int16_t h, const uint16_t *pcolors);
+  void writeSubImageRect(int16_t x, int16_t y, int16_t w, int16_t h, 
+                        int16_t image_offset_x, int16_t image_offset_y, int16_t image_width, int16_t image_height, 
+                        const uint16_t *pcolors);
+  void writeSubImageRectBytesReversed(int16_t x, int16_t y, int16_t w, int16_t h, 
+                        int16_t image_offset_x, int16_t image_offset_y, int16_t image_width, int16_t image_height, 
+                        const uint16_t *pcolors);
 
 // Frame buffer support
 #ifdef ENABLE_ST77XX_FRAMEBUFFER


### PR DESCRIPTION
There is an issue that charBounds did not use same calculations as actually used in the drawing of the text.  In most cases did not matter but for example
output of "-" will not offset correctly and y will be near bottom

Also for centered text, issue where it dived the offset to the starting of the drawing in half where it should be the whole offset.

@mjs513  - fixed like ili9341_t3n and ili9488_t3