### PR TITLE
Fix some pin names and constructors

### DIFF
--- a/examples/ILI_Ada_FontTest4/ILI_Ada_FontTest4.ino
+++ b/examples/ILI_Ada_FontTest4/ILI_Ada_FontTest4.ino
@@ -56,22 +56,22 @@ const ili_fonts_test_t font_test_list[] = {
 // Note: code will detect if specified pins are the hardware SPI pins
 //       and will use hardware SPI if appropriate
 // For 1.44" and 1.8" TFT with ST7735 use
-ST7789_t3 tft = ST7789_t3(TFT_CS, TFT_DC, TFT_MOSI, TFT_SCK, TFT_RST);
+//ST7789_t3 tft = ST7735_t3(TFT_CS, TFT_DC, TFT_MOSI, TFT_SCK, TFT_RST);
 
 // For 1.54" or other TFT with ST7789, This has worked with some ST7789
 // displays without CS pins, for those you can pass in -1 or 0xff for CS
 // More notes by the tft.init call
-//ST7789_t3 tft = ST7789_t3(TFT_CS, TFT_DC, TFT_MOSI, TFT_SCLK, TFT_RST);
+ST7789_t3 tft = ST7789_t3(TFT_CS, TFT_DC, TFT_MOSI, TFT_SCLK, TFT_RST);
 
 // Option 2: must use the hardware SPI pins
 // (for UNO thats sclk = 13 and sid = 11) and pin 10 must be
 // an output. This is much faster - also required if you want
 // to use the microSD card (see the image drawing example)
 // For 1.44" and 1.8" TFT with ST7735 use
-//ST7735_t3 tft = ST7735_t3(cs, dc, rst);
+//ST7735_t3 tft = ST7735_t3(TFT_CS, TFT_DC, TFT_RST);
 
 // For 1.54" TFT with ST7789
-//ST7789_t3 tft = ST7789_t3(TFT_CS,  TFT_DC, TFT_RST);
+//ST7789_t3 tft = ST7789_t3(TFT_CS, TFT_DC, TFT_RST);
 
 
 uint8_t test_screen_rotation = 0;

--- a/examples/graphicstest/graphicstest.ino
+++ b/examples/graphicstest/graphicstest.ino
@@ -51,22 +51,22 @@
 // Note: code will detect if specified pins are the hardware SPI pins
 //       and will use hardware SPI if appropriate
 // For 1.44" and 1.8" TFT with ST7735 use
-ST7789_t3 tft = ST7789_t3(TFT_CS, TFT_DC, TFT_MOSI, TFT_SCK, TFT_RST);
+//ST7789_t3 tft = ST7735_t3(TFT_CS, TFT_DC, TFT_MOSI, TFT_SCK, TFT_RST);
 
 // For 1.54" or other TFT with ST7789, This has worked with some ST7789
 // displays without CS pins, for those you can pass in -1 or 0xff for CS
 // More notes by the tft.init call
-//ST7789_t3 tft = ST7789_t3(TFT_CS, TFT_DC, TFT_MOSI, TFT_SCLK, TFT_RST);
+ST7789_t3 tft = ST7789_t3(TFT_CS, TFT_DC, TFT_MOSI, TFT_SCLK, TFT_RST);
 
 // Option 2: must use the hardware SPI pins
 // (for UNO thats sclk = 13 and sid = 11) and pin 10 must be
 // an output. This is much faster - also required if you want
 // to use the microSD card (see the image drawing example)
 // For 1.44" and 1.8" TFT with ST7735 use
-//ST7735_t3 tft = ST7735_t3(cs, dc, rst);
+//ST7735_t3 tft = ST7735_t3(TFT_CS, TFT_DC, TFT_RST);
 
 // For 1.54" TFT with ST7789
-//ST7789_t3 tft = ST7789_t3(TFT_CS,  TFT_DC, TFT_RST);
+//ST7789_t3 tft = ST7789_t3(TFT_CS, TFT_DC, TFT_RST);
 
 float p = 3.1415926;
 


### PR DESCRIPTION
For the Verbose version, there was an ST7735 and an ST7789 version, but the ST7735 was accidentally edited to ST7789 version... So fixed that but still left the ST7789 as default one by un-commenting the appropriate lines.

Also fixed teh short version of the ST7735 constructor which was using (cs, dc, rst) instead of what all of the others were using (TFT_CS, TFT_DC, TFT_RST)

Two examples were this way.

I did verify that at least in the graphictest case, I was then able to comment out the ST7789 constructor and uncomment the fixed one for ST7735 and then change which init was called and it builds again