### PR TITLE
The pixel code was using wrong variable

### DIFF
--- a/ST7735_t3.h
+++ b/ST7735_t3.h
@@ -833,7 +833,8 @@ class ST7735_t3 : public Print
 
 		#ifdef ENABLE_ST77XX_FRAMEBUFFER
 	  	if (_use_fbtft) {
-	  		_pfbtft[y*_screenWidth + x] = color;
+        int pixel_index = (int)y*(int)_width + x;
+	  		_pfbtft[pixel_index] = color;
 	  		return;
 	  	}
 	  	#endif


### PR DESCRIPTION
It was using, the _screenWidth member variable, which is the size of the screen, as passed into init.

Should be using _width, which was setup from _screenWidth and _screenHeight depending on orientation.

@mjs513 - we should doublecheck this is not repeated in other libraries as well.