### PR TITLE
updateScreen() support using clip rectangle

### DIFF
--- a/examples/ILI_Ada_FontTest4/ILI_Ada_FontTest4.ino
+++ b/examples/ILI_Ada_FontTest4/ILI_Ada_FontTest4.ino
@@ -56,12 +56,12 @@ const ili_fonts_test_t font_test_list[] = {
 // Note: code will detect if specified pins are the hardware SPI pins
 //       and will use hardware SPI if appropriate
 // For 1.44" and 1.8" TFT with ST7735 use
-//ST7789_t3 tft = ST7735_t3(TFT_CS, TFT_DC, TFT_MOSI, TFT_SCK, TFT_RST);
+//ST7735_t3 tft = ST7735_t3(TFT_CS, TFT_DC, TFT_MOSI, TFT_SCK, TFT_RST);
 
 // For 1.54" or other TFT with ST7789, This has worked with some ST7789
 // displays without CS pins, for those you can pass in -1 or 0xff for CS
 // More notes by the tft.init call
-ST7789_t3 tft = ST7789_t3(TFT_CS, TFT_DC, TFT_MOSI, TFT_SCLK, TFT_RST);
+ST7789_t3 tft = ST7789_t3(TFT_CS, TFT_DC, TFT_MOSI, TFT_SCK, TFT_RST);
 
 // Option 2: must use the hardware SPI pins
 // (for UNO thats sclk = 13 and sid = 11) and pin 10 must be

--- a/src/ST7735_t3.cpp
+++ b/src/ST7735_t3.cpp
@@ -1042,6 +1042,7 @@ void ST7735_t3::drawPixel(int16_t x, int16_t y, uint16_t color)
 
 	#ifdef ENABLE_ST77XX_FRAMEBUFFER
 	if (_use_fbtft) {
+    updateChangedRange(x, y); // update the range of the screen that has been changed;
 		_pfbtft[y*_width + x] = color;
 
 	} else 
@@ -1068,6 +1069,8 @@ void ST7735_t3::drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color)
 
 	#ifdef ENABLE_ST77XX_FRAMEBUFFER
 	if (_use_fbtft) {
+    updateChangedRange(
+        x, y, 1, h); // update the range of the screen that has been changed;
 		uint16_t * pfbPixel = &_pfbtft[ y*_width + x];
 		while (h--) {
 			*pfbPixel = color;
@@ -1101,6 +1104,8 @@ void ST7735_t3::drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color)
 
 	#ifdef ENABLE_ST77XX_FRAMEBUFFER
 	if (_use_fbtft) {
+    updateChangedRange(
+        x, y, w, 1); // update the range of the screen that has been changed;
 		if ((x&1) || (w&1)) {
 			uint16_t * pfbPixel = &_pfbtft[ y*_width + x];
 			while (w--) {
@@ -1150,6 +1155,8 @@ void ST7735_t3::fillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t co
 
 	#ifdef ENABLE_ST77XX_FRAMEBUFFER
 	if (_use_fbtft) {
+    updateChangedRange(
+        x, y, w, h); // update the range of the screen that has been changed;
 		if ((x&1) || (w&1)) {
 			uint16_t * pfbPixel_row = &_pfbtft[ y*_width + x];
 			for (;h>0; h--) {
@@ -1378,19 +1385,42 @@ void ST7735_t3::writeRect(int16_t x, int16_t y, int16_t w, int16_t h, const uint
 
 	#ifdef ENABLE_ST77XX_FRAMEBUFFER
 	if (_use_fbtft) {
-		uint16_t * pfbPixel_row = &_pfbtft[ y*_width + x];
-		for (;h>0; h--) {
-			uint16_t * pfbPixel = pfbPixel_row;
-			pcolors += x_clip_left;
-			for (int i = 0 ;i < w; i++) {
-				*pfbPixel++ = *pcolors++;
-			}
-			pfbPixel_row += _width;
-			pcolors += x_clip_right;
+		    uint16_t *pfbPixel_row = &_pfbtft[y * _width + x];
+    int16_t y_changed_min = _height;
+    int16_t y_changed_max = -1;
+    int16_t i_changed_min = _width;
+    int16_t i_changed_max = -1;
 
-		}
-		return;	
-	}
+    for (; h > 0; h--) {
+      uint16_t *pfbPixel = pfbPixel_row;
+      pcolors += x_clip_left;
+      for (int i = 0; i < w; i++) {
+        if (*pfbPixel != *pcolors) {
+          // pixel changed
+          *pfbPixel = *pcolors;
+          if (y < y_changed_min) y_changed_min = y;
+          if (y > y_changed_max) y_changed_max = y;
+          if (i < i_changed_min) i_changed_min = i;
+          if (i > i_changed_max) i_changed_max = i;
+
+        }
+        pfbPixel++;
+        pcolors++;
+      }
+      pfbPixel_row += _width;
+      pcolors += x_clip_right;
+      y++;
+    }
+    // See if we found any chang
+    // if any of the min/max values have default value we know that nothing changed.
+    if (y_changed_max != -1) {
+      updateChangedRange(x + i_changed_min , y_changed_min, 
+        (i_changed_max - i_changed_min) + 1, (y_changed_max - y_changed_min) + 1);
+
+      //if(Serial)Serial.printf("WRECT: %d - %d %d %d %d\n", x, i_changed_min, y_changed_min, i_changed_max, y_changed_max);
+    }
+    return;
+  }
 	#endif
 
    	beginSPITransaction();
@@ -1607,7 +1637,9 @@ void ST7735_t3::writeRect8BPP(int16_t x, int16_t y, int16_t w, int16_t h,
 // x_clip_right, x_clip_left);
 #ifdef ENABLE_ST77XX_FRAMEBUFFER
   if (_use_fbtft) {
-    uint16_t *pfbPixel_row = &_pfbtft[y * _width + x];
+  	updateChangedRange(
+        x, y, w, h); // update the range of the screen that has been changed;
+      uint16_t *pfbPixel_row = &_pfbtft[y * _width + x];
     for (; h > 0; h--) {
       pixels += x_clip_left;
       uint16_t *pfbPixel = pfbPixel_row;
@@ -1741,7 +1773,9 @@ void ST7735_t3::writeRectNBPP(int16_t x, int16_t y, int16_t w, int16_t h,
 
 #ifdef ENABLE_ST77XX_FRAMEBUFFER
   if (_use_fbtft) {
-    uint16_t *pfbPixel_row = &_pfbtft[y * _width + x];
+  	updateChangedRange(
+        x, y, w, h); // update the range of the screen that has been changed;
+      uint16_t *pfbPixel_row = &_pfbtft[y * _width + x];
     for (; h > 0; h--) {
       uint16_t *pfbPixel = pfbPixel_row;
       pixels = pixels_row_start;            // setup for this row
@@ -2627,6 +2661,9 @@ void ST7735_t3::drawChar(int16_t x, int16_t y, unsigned char c,
 
 		#ifdef ENABLE_ST77XX_FRAMEBUFFER
 		if (_use_fbtft) {
+      updateChangedRange(
+          x, y, 6 * size_x,
+          8 * size_y); // update the range of the screen that has been changed;
 			uint16_t * pfbPixel_row = &_pfbtft[ y*_width + x];
 			for (yc=0; (yc < 8) && (y < _displayclipy2); yc++) {
 				for (yr=0; (yr < size_y) && (y < _displayclipy2); yr++) {
@@ -3041,6 +3078,12 @@ void ST7735_t3::drawFontChar(unsigned int c)
 */
 		#ifdef ENABLE_ST77XX_FRAMEBUFFER
 		if (_use_fbtft) {
+      updateChangedRange(
+          start_x,
+          start_y); // update the range of the screen that has been changed;
+      updateChangedRange(
+          end_x,
+          end_y); // update the range of the screen that has been changed;
 			uint16_t * pfbPixel_row = &_pfbtft[ start_y*_width + start_x];
 			uint16_t * pfbPixel;
 			int screen_y = start_y;
@@ -3766,6 +3809,12 @@ void ST7735_t3::drawGFXFontChar(unsigned int c) {
 		#ifdef ENABLE_ST77XX_FRAMEBUFFER
 		if (_use_fbtft) {
 			// lets try to output the values directly...
+      updateChangedRange(
+          x_start,
+          y_start); // update the range of the screen that has been changed;
+      updateChangedRange(
+          x_end,
+          y_end); // update the range of the screen that has been changed;
 			uint16_t * pfbPixel_row = &_pfbtft[ y_start *_width + x_start];
 			uint16_t * pfbPixel;
 			// First lets fill in the top parts above the actual rectangle...
@@ -4225,7 +4274,7 @@ void ST7735_t3::updateScreen(void)					// call to say update the screen now.
 	// Will go by buffer as maybe can do interesting things?
 	if (_use_fbtft) {
 		beginSPITransaction();
-		if (_standard) {
+		if (_standard && !_updateChangedAreasOnly) {
 			// Doing full window. 
 			setAddr(0, 0, _width-1, _height-1);
 			writecommand(ST7735_RAMWR);
@@ -4247,6 +4296,19 @@ void ST7735_t3::updateScreen(void)					// call to say update the screen now.
       int16_t start_y = _displayclipy1;
       int16_t end_x = _displayclipx2 - 1;
       int16_t end_y = _displayclipy2 - 1;
+
+      if (_updateChangedAreasOnly) {
+        // maybe update range of values to update...
+        if (_changed_min_x > start_x)
+          start_x = _changed_min_x;
+        if (_changed_min_y > start_y)
+          start_y = _changed_min_y;
+        if (_changed_max_x < end_x)
+          end_x = _changed_max_x;
+        if (_changed_max_y < end_y)
+          end_y = _changed_max_y;
+      }
+
       //if (Serial) Serial.printf("updateScreen: (%u %u) - (%u %u)\n", start_x, start_y, end_x, end_y);
       if ((start_x <= end_x) && (start_y <= end_y)) {
         setAddr(start_x, start_y, end_x, end_y);
@@ -4272,6 +4334,7 @@ void ST7735_t3::updateScreen(void)					// call to say update the screen now.
 
 		endSPITransaction();
 	}
+  clearChangedRange(); // make sure the dirty range is updated.
 }			 
 
 #ifdef DEBUG_ASYNC_UPDATE

--- a/src/ST7789_t3.cpp
+++ b/src/ST7789_t3.cpp
@@ -82,32 +82,22 @@ void  ST7789_t3::setRotation(uint8_t m)
      writedata_last(ST77XX_MADCTL_MY | ST77XX_MADCTL_MV | ST77XX_MADCTL_RGB);
 
      _xstart = _rowstart;
-     _ystart = _colstart;
+     _ystart = _colstart2;
      _height = _screenWidth;
      _width = _screenHeight;
      break;
   case 2:
      writedata_last(ST77XX_MADCTL_RGB); 
-    if ((_screenWidth == 135) && (_screenHeight == 240)) {
-      _xstart = _colstart - 1;
-      _ystart = _rowstart;
-    } else {
-      _xstart = 0;
-      _ystart = 0;
-    }
+     _xstart = _colstart2;
+     _ystart = _rowstart2;
      _width = _screenWidth;
      _height = _screenHeight;
      break;
 
    case 3:
      writedata_last(ST77XX_MADCTL_MX | ST77XX_MADCTL_MV | ST77XX_MADCTL_RGB);
-    if ((_screenWidth == 135) && (_screenHeight == 240)) {
-      _xstart = _rowstart;
-      _ystart = _colstart;
-    } else {
-      _xstart = 0;
-      _ystart = 0;
-    }
+     _xstart = _rowstart2;
+     _ystart = _colstart;
      _height = _screenWidth;
      _width = _screenHeight;
      break;
@@ -163,15 +153,21 @@ void  ST7789_t3::init(uint16_t width, uint16_t height, uint8_t mode)
   Serial.printf("ST7789_t3::init mode: %x\n", mode);
 	commonInit(NULL, mode);
 
+  // Add in support for other widths and heights.
   if ((width == 240) && (height == 240)) {
     _colstart = 0;
+    _colstart2 = 0;
     _rowstart = 80;
+    _rowstart2 = 0;
   } else if ((width == 135) && (height == 240)) { // 1.13" display Their smaller display
     _colstart = 53;
+    _colstart2 = 52;  // odd size
     _rowstart = 40;
-  } else {
-    _colstart = 0;
-    _rowstart = 0;
+    _rowstart2 = 40;
+  } else {  // lets compute it.
+    // added support for other sizes
+    _rowstart = _rowstart2 = (int)((320 - height) / 2);
+    _colstart = _colstart2 = (int)((240 - width) / 2);
   }
   
   _height = height;

--- a/src/ST7789_t3.h
+++ b/src/ST7789_t3.h
@@ -30,6 +30,10 @@ class ST7789_t3 : public ST7735_t3 {
   virtual void  setRotation(uint8_t m);
 
   void  init(uint16_t width=240, uint16_t height=240, uint8_t mode=SPI_MODE0);
+protected:
+    uint8_t _colstart2 = 0; // Offset from the right added to handle additional display sizes
+    uint8_t _rowstart2 = 0; // Offset from the bottom
+
 };
 
 


### PR DESCRIPTION
Hi @PaulStoffregen @mjs513,

The ST77xx code did not have the code in place to support doing updateScreen from Frame buffer and have it only update the area within current clip rectangle, like some of the others do. 

So added it.  This does not yet include the code that figures out what areas of the display have been updated (dirty) and use that setting.  not sure yet if that was added into all of the graphic primitives.  Will check and see if I can simply add a few checks and sets, else need to merge in some more code. 

Using the clip code to limit how much of the display gets updated can speed up things a lot in some cases.

Can merge nor or wait and see if we try to add in additional stuff. 

Longer term may update these drivers to allow the clip code to work in the Asyn updates using DMA.  

Now off to play