### PR TITLE
perf: transmit RASET/CASET only when changed

### DIFF
--- a/src/ST7735_t3.cpp
+++ b/src/ST7735_t3.cpp
@@ -1012,7 +1012,6 @@ void ST7735_t3::setAddrWindow(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1
 {
 	beginSPITransaction();
 	setAddr(x0, y0, x1, y1);
-	writecommand(ST7735_RAMWR); // write to RAM
 	// The setAddrWindow/pushColor will only work if SPI is kept active during this loop...
 	endSPITransaction();
 }
@@ -1050,7 +1049,6 @@ void ST7735_t3::drawPixel(int16_t x, int16_t y, uint16_t color)
 	{
 		beginSPITransaction();
 		setAddr(x,y,x+1,y+1);
-		writecommand(ST7735_RAMWR);
 		writedata16_last(color);
 		endSPITransaction();
 	}
@@ -1081,7 +1079,6 @@ void ST7735_t3::drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color)
 	{
 		beginSPITransaction();
 		setAddr(x, y, x, y+h-1);
-		writecommand(ST7735_RAMWR);
 		while (h-- > 1) {
 			writedata16(color);
 		}
@@ -1125,7 +1122,6 @@ void ST7735_t3::drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color)
 	{
 		beginSPITransaction();
 		setAddr(x, y, x+w-1, y);
-		writecommand(ST7735_RAMWR);
 		while (w-- > 1) {
 			writedata16(color);
 		}
@@ -1188,7 +1184,6 @@ void ST7735_t3::fillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t co
 		// it'll cost more overhead, so we don't stall other SPI libs
 		beginSPITransaction();
 		setAddr(x, y, x+w-1, y+h-1);
-		writecommand(ST7735_RAMWR);
 		for(y=h; y>0; y--) {
 			for(x=w; x>1; x--) {
 				writedata16(color);
@@ -1425,7 +1420,6 @@ void ST7735_t3::writeRect(int16_t x, int16_t y, int16_t w, int16_t h, const uint
 
    	beginSPITransaction();
 	setAddr(x, y, x+w-1, y+h-1);
-	writecommand(ST7735_RAMWR);
 	for(y=h; y>0; y--) {
 		pcolors += x_clip_left;
 		for(x=w; x>1; x--) {
@@ -1496,7 +1490,6 @@ void ST7735_t3::writeSubImageRect(int16_t x, int16_t y, int16_t w, int16_t h,
 
   beginSPITransaction();
   setAddr(x, y, x+w-1, y+h-1);
-  writecommand(ST7735_RAMWR);
   for(y=h; y>0; y--) {
     const uint16_t *pcolors_row = pcolors; 
     for(x=w; x>1; x--) {
@@ -1567,7 +1560,6 @@ void ST7735_t3::writeSubImageRectBytesReversed(int16_t x, int16_t y, int16_t w, 
 
   beginSPITransaction();
   setAddr(x, y, x+w-1, y+h-1);
-  writecommand(ST7735_RAMWR);
   for(y=h; y>0; y--) {
     const uint16_t *pcolors_row = pcolors; 
     for(x=w; x>1; x--) {
@@ -1655,7 +1647,6 @@ void ST7735_t3::writeRect8BPP(int16_t x, int16_t y, int16_t w, int16_t h,
 
   beginSPITransaction();
   setAddr(x, y, x + w - 1, y + h - 1);
-  writecommand(ST7735_RAMWR);
   for (y = h; y > 0; y--) {
     pixels += x_clip_left;
     // Serial.printf("%x: ", (uint32_t)pixels);
@@ -1799,7 +1790,6 @@ void ST7735_t3::writeRectNBPP(int16_t x, int16_t y, int16_t w, int16_t h,
 
   beginSPITransaction();
   setAddr(x, y, x + w - 1, y + h - 1);
-  writecommand(ST7735_RAMWR);
   for (; h > 0; h--) {
     pixels = pixels_row_start;            // setup for this row
     uint8_t pixel_shift = row_shift_init; // Setup mask
@@ -2715,7 +2705,6 @@ void ST7735_t3::drawChar(int16_t x, int16_t y, unsigned char c,
 			setAddr(x, y, x + w -1, y + h - 1);
 
 			y = y_char_top;	// restore the actual y.
-			writecommand(ST7735_RAMWR);
 			for (yc=0; (yc < 8) && (y < _displayclipy2); yc++) {
 				for (yr=0; (yr < size_y) && (y < _displayclipy2); yr++) {
 					x = x_char_start; 		// get our first x position...
@@ -3231,7 +3220,6 @@ void ST7735_t3::drawFontChar(unsigned int c)
 			//Serial.printf("SetAddr %d %d %d %d\n", start_x_min, start_y_min, end_x, end_y);
 			// output rectangle we are updating... We have already clipped end_x/y, but not yet start_x/y
 			setAddr( start_x, start_y_min, end_x, end_y);
-			writecommand(ST7735_RAMWR);
 			int screen_y = start_y_min;
 			int screen_x;
 
@@ -3911,7 +3899,6 @@ void ST7735_t3::drawGFXFontChar(unsigned int c) {
 			setAddr((x_start >= _displayclipx1) ? x_start : _displayclipx1, 
 					(y_start >= _displayclipy1) ? y_start : _displayclipy1, 
 					x_end  - 1,  y_end - 1); 
-			writecommand(ST7735_RAMWR);
 			//Serial.printf("SetAddr: %u %u %u %u\n", (x_start >= _displayclipx1) ? x_start : _displayclipx1, 
 			//		(y_start >= _displayclipy1) ? y_start : _displayclipy1, 
 			//		x_end  - 1,  y_end - 1); 
@@ -4277,7 +4264,6 @@ void ST7735_t3::updateScreen(void)					// call to say update the screen now.
 		if (_standard && !_updateChangedAreasOnly) {
 			// Doing full window. 
 			setAddr(0, 0, _width-1, _height-1);
-			writecommand(ST7735_RAMWR);
 
 			// BUGBUG doing as one shot.  Not sure if should or not or do like
 			// main code and break up into transactions...
@@ -4312,7 +4298,6 @@ void ST7735_t3::updateScreen(void)					// call to say update the screen now.
       //if (Serial) Serial.printf("updateScreen: (%u %u) - (%u %u)\n", start_x, start_y, end_x, end_y);
       if ((start_x <= end_x) && (start_y <= end_y)) {
         setAddr(start_x, start_y, end_x, end_y);
-        writecommand(ST7735_RAMWR);
 
         // BUGBUG doing as one shot.  Not sure if should or not or do like
         // main code and break up into transactions...
@@ -4619,7 +4604,6 @@ bool ST7735_t3::updateScreenAsync(bool update_cont)					// call to say update th
 
 	// Doing full window. 
 	setAddr(0, 0, _width-1, _height-1);
-	writecommand(ST7735_RAMWR);
 
 	// Write the first Word out before enter DMA as to setup the proper CS/DC/Continue flaugs
 	writedata16(*_pfbtft);
@@ -4650,7 +4634,7 @@ bool ST7735_t3::updateScreenAsync(bool update_cont)					// call to say update th
 // Doing full window.
 
   setAddr(0, 0, _width - 1, _height - 1);
-  writecommand_last(ST7735_RAMWR);
+  waitTransmitComplete();
 
   // Update TCR to 16 bit mode. and output the first entry.
   _spi_fcr_save = _pimxrt_spi->FCR; // remember the FCR
@@ -4699,7 +4683,6 @@ bool ST7735_t3::updateScreenAsync(bool update_cont)					// call to say update th
 	beginSPITransaction();
 	// Doing full window. 
 	setAddr(0, 0, _width-1, _height-1);
-	writecommand(ST7735_RAMWR);
 
 	// Write the first Word out before enter DMA as to setup the proper CS/DC/Continue flaugs
 	// On T3.5 DMA only appears to work with CTAR 0 so hack it up...

--- a/src/ST7735_t3.h
+++ b/src/ST7735_t3.h
@@ -235,34 +235,31 @@ class ST7735_t3 : public Print
   void setAddr(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1)
     __attribute__((always_inline)) {
         // Keep a copy of the last address window transmitted.
-	// Do not transmit it again until the window actually changes.
-        static uint16_t _x0 = 0xFFFF, _y0 = 0xFFFF, 
-                        _x1 = 0xFFFF, _y1 = 0xFFFF;
-
-        // TBD: Guard these under the same conditions as CASET/RASET below?
-        //  But the bottleneck is SPI throughput/contention, not 16-bit ADDs.
+        // Do not transmit it again until the window actually changes.
         x0 += _xstart;
         x1 += _xstart;
         y0 += _ystart;
         y1 += _ystart;
 
-        if (x0 != _x0 || x1 != _x1) {
+        if (!_is_addr_win_x_set || x0 != _addr_win_x0 || x1 != _addr_win_x1) {
             writecommand(ST7735_CASET); // Column addr set
             writedata16(x0);   // XSTART 
             writedata16(x1);   // XEND
-            _x0 = x0;
-            _x1 = x1;
+            _addr_win_x0 = x0;
+            _addr_win_x1 = x1;
+            _is_addr_win_x_set = true;
         }
 
-        if (y0 != _y0 || y1 != _y1) {
+        if (!_is_addr_win_y_set || y0 != _addr_win_y0 || y1 != _addr_win_y1) {
             writecommand(ST7735_RASET); // Row addr set
             writedata16(y0);   // YSTART
             writedata16(y1);   // YEND
-            _y0 = y0;
-            _y1 = y1;
+            _addr_win_y0 = y0;
+            _addr_win_y1 = y1;
+            _is_addr_win_y_set = true;
         }
 
-	writecommand(ST7735_RAMWR); // Write to RAM
+        writecommand(ST7735_RAMWR); // Write to RAM
   }
 
   ////
@@ -522,7 +519,12 @@ class ST7735_t3 : public Print
 			//Serial.printf("UDC (%d %d)-(%d %d) %d %d\n", _displayclipx1, _displayclipy1, _displayclipx2, _displayclipy2, _invisible, _standard);
 		}
 	}
-	
+
+	bool _is_addr_win_x_set = false,
+	     _is_addr_win_y_set = false;
+	uint16_t _addr_win_x0 = 0xFFFF, _addr_win_x1 = 0xFFFF,
+	         _addr_win_y0 = 0xFFFF, _addr_win_y1 = 0xFFFF;
+
 	int16_t _width, _height;
 	int16_t scroll_x, scroll_y, scroll_width, scroll_height;
 	boolean scrollEnable,isWritingScrollArea; // If set, 'wrap' text at right edge of display


### PR DESCRIPTION
These display drivers always write color data to the screen region defined by their row address (`RA`) and column address (`CA`) registers. 

The SPI command to update the addresses in these registers are `RASET` and `CASET`. It is not necessary to re-transmit `RASET`/`CASET` when refreshing the color data in the same address window repeatedly. 

Apparently, it is **extremely** common for graphics drivers to refresh a fixed region of the display (full-screen refresh, dirty rectangles, bitmap fonts/sprites, etc.). So this optimization yields a substantial performance improvement in nearly all cases without penalty.

Also, the call to `writecommand(ST7735_RAMWR)` has been refactored into the `setAddr` routine. You can easily see from the patch that this command is always transmitted immediately following calls to `setAddr`. So this merely reduces a lot of duplicate lines.