### PR TITLE
Update ST7735_t3.cpp segment SPI fillRect

### DIFF
--- a/src/ST7735_t3.cpp
+++ b/src/ST7735_t3.cpp
@@ -1194,6 +1194,10 @@ void ST7735_t3::fillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t co
 				writedata16(color);
 			}
 			writedata16_last(color);		
+			if (y > 1 && (y & 1)) {
+				endSPITransaction();
+				beginSPITransaction();
+			}
 		}
 		endSPITransaction();
 	}

--- a/src/ST7735_t3.cpp
+++ b/src/ST7735_t3.cpp
@@ -1144,7 +1144,9 @@ void ST7735_t3::fillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t co
 {
 	x+=_originx;
 	y+=_originy;
-
+	int bbig=0; // Break Big Rectangles, not small font calls
+	if ( w*h > 100 ) bbig=1;
+	
 	// Rectangular clipping (drawChar w/big text requires this)
 	if((x >= _displayclipx2) || (y >= _displayclipy2)) return;
 	if (((x+w) <= _displayclipx1) || ((y+h) <= _displayclipy1)) return;
@@ -1194,7 +1196,7 @@ void ST7735_t3::fillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t co
 				writedata16(color);
 			}
 			writedata16_last(color);		
-			if (y > 1 && (y & 1)) {
+			if (bbig && y > 1 && (y & 1)) {
 				endSPITransaction();
 				beginSPITransaction();
 			}


### PR DESCRIPTION
fillRect gets SPI end & begin to free the bus 
It was breaking Audio playback
>Even though It is using SDIO SD_BUILTIN to read for: Part_3_03_TFT_Display.ino, 

This code copied from ILI9341_t3 as seen on thread: https://forum.pjrc.com/index.php?threads/st7796-teensyduino-support.76510/post-358075