### PR TITLE
Update library.properties dot_a_linkage to FALSE

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=Teensy optimized library for ST7735, ST7789 and ST7796 SPI displays.
 category=Display
 url=https://github.com/PaulStoffregen/ST7735_t3
 architectures=*
-dot_a_linkage=true
+dot_a_linkage=false


### PR DESCRIPTION
Causes build errors with mixed C and CPP at times in the IDE

Noted as correction by @KurtE and found to resolve issue with library class functions not seen in link